### PR TITLE
Add Type Definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "typings": "types/index.d.ts",
   "files": [
-    "index.js"
+    "index.js",
+    "types/index.d.ts"
   ],
   "repository": {
     "type": "git",
@@ -30,6 +32,7 @@
     "nativescript-toasty": "*",
     "nativescript-socketio": "*",
     "tns-core-modules": "*",
-    "@vue/devtools": "*"
+    "@vue/devtools": "*",
+    "vue": "*"
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,3 @@
+import _Vue from "vue";
+
+export declare function install(Vue: typeof _Vue): void;


### PR DESCRIPTION
After having executed `vue init nativescript-vue/vue-cli-template <project-name>`, setting `strict` to `true` in my `tsconfig.json`, and installing TSLint, I noted that this package didn't have any type definitions, which felt a little strange given that it's possible to be included in a generated TypeScript project!